### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,10 @@
   "active": false,
   "exercises": [
     {
+      "uuid": "cc5f77d1-b94d-4a05-b205-08eaa00bf49e",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "primitives",
@@ -13,28 +16,40 @@
       ]
     },
     {
+      "uuid": "f0bcb245-9e02-476c-9470-5f41c9358960",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "iterators"
       ]
     },
     {
+      "uuid": "3b11a07d-1d32-4dc1-b580-7ceaefa5ddd6",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings"
       ]
     },
     {
+      "uuid": "c2f970d3-810c-4504-8592-f523b1d61cbb",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "errors"
       ]
     },
     {
+      "uuid": "f4174500-ae74-499a-9f7b-638238a28843",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "math",
@@ -42,7 +57,10 @@
       ]
     },
     {
+      "uuid": "4471c6ee-1dfa-4520-99fb-aa1f9a543053",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "reference capabilities",
@@ -50,7 +68,10 @@
       ]
     },
     {
+      "uuid": "27087d27-8ca9-48e7-af64-fda35af114f4",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -59,7 +80,10 @@
       ]
     },
     {
+      "uuid": "94829aed-9496-47d4-b43d-ad2f3ea2a839",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "strings",
@@ -68,7 +92,10 @@
       ]
     },
     {
+      "uuid": "fc48383d-9e1c-49a0-955f-b14bcbd3e801",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -76,7 +103,10 @@
       ]
     },
     {
+      "uuid": "bd0cb4f4-b1d9-412f-ac35-c4b4136260d7",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -84,7 +114,10 @@
       ]
     },
     {
+      "uuid": "bb3fa1fd-6472-4806-bd1f-642541437d40",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "math",


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16