### PR TITLE
Fix dead link in RESOURCES.md

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -2,6 +2,6 @@
 
 - [The Pony Tutorial](https://tutorial.ponylang.org/)
 - [Pony Patterns](https://patterns.ponylang.org/)
-- [Standard Library Documentation](http://www.ponylang.org/ponyc/)
+- [Standard Library Documentation](https://stdlib.ponylang.org/)
 - [Mailing List](https://pony.groups.io/g/pony)
 - [IRC Channel](https://webchat.freenode.net/?channels=%23ponylang)


### PR DESCRIPTION
Dead link in RESOURCES.md now gets directed to the correct page for Standard Lib Docs