### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,7 +22,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "iterators"
+        "iterators",
+        "math"
       ]
     },
     {
@@ -52,8 +53,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "booleans",
-        "math"
+        "booleans"
       ]
     },
     {
@@ -87,7 +87,6 @@
       "difficulty": 2,
       "topics": [
         "errors",
-        "math",
         "strings"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110