### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [Pony](http://www.ponylang.org) is an object-oriented, actor-model, capabilities-secure programming language focused on geting stuff done.
 
 It's object-oriented because it has classes and objects, like Python, Java, C++, and many other languages. It's actor-model because it has actors (similar to Erlang or Akka). These behave like objects, but they can also execute code asynchronously. Actors make Pony awesome.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,12 +1,12 @@
 # Installing the Pony Compiler
 
-### Homebrew on Mac OS X
+## Homebrew on Mac OS X
 
 ```bash
 brew update
 brew install ponyc
 ```
 
-### Other Platforms
+## Other Platforms
 
 Instructions for installing Pony can be found in the [ponyc installation](https://github.com/ponylang/ponyc/blob/master/README.md#installation)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,4 +1,4 @@
-## Installing the Pony Compiler
+# Installing the Pony Compiler
 
 ### Homebrew on Mac OS X
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,4 @@
-## Resources for Learning Pony:
+# Resources for Learning Pony:
 
 - [The Pony Tutorial](https://tutorial.ponylang.org/)
 - [Pony Patterns](https://patterns.ponylang.org/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,4 +1,4 @@
-## Resources for Learning Pony
+# Resources for Learning Pony
 
 - [The Pony Tutorial](https://tutorial.ponylang.org/)
 - [Pony Patterns](https://patterns.ponylang.org/)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## Running tests
+# Running tests
 
 To compile and run the tests, just run the following in your exercise directory:
 ```bash


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
