### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "70614e9e-6325-4718-9b29-1bdf389f6af8",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Pony locally",
+      "blurb": "Learn how to install Pony locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "b4458454-3a7a-4c10-a6c3-aebc1980aaf1",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Pony",
+      "blurb": "An overview of how to get started from scratch with Pony"
+    },
+    {
+      "uuid": "025fe9bc-ba67-4bd2-a235-d509f0a46bec",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Pony track",
+      "blurb": "Learn how to test your Pony exercises on Exercism"
+    },
+    {
+      "uuid": "b7b02764-785e-4cdf-9b9d-b6e37e8d99c9",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Pony resources",
+      "blurb": "A collection of useful resources to help you master Pony"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
